### PR TITLE
Update Cargo.toml add repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0-dev4"
 edition = "2021"
 license = "MIT"
 description = "common utils functions in rust"
+repository = "https://github.com/claudezss/r-utils"
 
 
 [lib]


### PR DESCRIPTION
to allow crates.io, rust-digger, and others to link to it